### PR TITLE
Update SORACOM-LPWAN-with-features.csv - incl. planNT1

### DIFF
--- a/SORACOM-LPWAN-with-features.csv
+++ b/SORACOM-LPWAN-with-features.csv
@@ -5,38 +5,50 @@ Austria,AUT,23201,A1,NB-IoT,B20,plan01s,Guaranteed,PSM and eDRX | SMS,08/20/2024
 Austria,AUT,23201,A1,NB-IoT,B20,planX3,Guaranteed,PSM and eDRX | SMS,09/30/2024
 Austria,AUT,23203,Magenta,NB-IoT,B8,plan01s,Guaranteed,PSM or eDRX,08/20/2024
 Azerbaijan,AZE,40001,Azercell,NB-IoT,B3,plan01s,Validated,SMS,07/02/2025
+Azerbaijan,AZE,40001,Azercell,NB-IoT,B3,planNT1,Validated,SMS,07/02/2025
 Bahrain,BHR,42602,Zain,NB-IoT,B20,plan01s,Validated,SMS,07/02/2025
+Bahrain,BHR,42602,Zain,NB-IoT,B20,planNT1,Validated,SMS,07/02/2025
 Belgium,BEL,20620,Base,NB-IoT,B20,plan01s,Guaranteed,PSM and eDRX,05/06/2025
 Belgium,BEL,20601,Proximus,NB-IoT,B20,plan01s,Guaranteed,PSM and eDRX,05/01/2025
 Belgium,BEL,20610,Orange,NB-IoT,B20,plan01s,Guaranteed,PSM* and eDRX,06/04/2024
+Belgium,BEL,20610,Orange,NB-IoT,B20,planNT1,Guaranteed,,12/01/2024
 Belgium,BEL,20610,Orange,NB-IoT,B20,planX3,Guaranteed,PSM* and eDRX,11/05/2024
 Canada,CAN,302720,Rogers,NB-IoT,B12,plan01s,Validated,SMS,08/20/2024
 Canada,CAN,302720,Rogers,NB-IoT,B12,plan-NA1,Validated,SMS,06/04/2024
+Canada,CAN,302720,Rogers,NB-IoT,B12,planNT1,Validated,-,01/23/2024
 Canada,CAN,302720,Rogers,NB-IoT,B12,planP1,Validated,-,06/25/2024
 Canada,CAN,302720,Rogers,NB-IoT,B12,plan-US-NA,Validated,-,06/25/2024
 Chile,CHL,73001,Entel,NB-IoT,B2 | B28,plan01s,Validated,PSM and eDRX,06/05/2024
 Chile,CHL,73003,Claro,NB-IoT,B28,planP1,Validated,PSM and eDRX,07/19/2024
 Chile,CHL,73003,Claro,NB-IoT,B28,plan01s,Validated,PSM and eDRX | SMS,04/28/2025
-China,CHN,46000,China Mobile,NB-IoT,B8,plan01s,Validated,SMS,03/25/2025
-China,CHN,46000,China Mobile,NB-IoT,B8,planP1,Validated,eDRX | SMS (MT),06/11/2024
+China,CHN,46000,China Mobile,NB-IoT,B8,plan01s,Validated,SMS,09/12/2025
+China,CHN,46000,China Mobile,NB-IoT,B8,planNT1,Validated,SMS,09/12/2025
+China,CHN,46000,China Mobile,NB-IoT,B8,planP1,Validated,eDRX | SMS (MT),09/12/2025
 Czech,CZE,23003,Vodafone,NB-IoT,B20,planX3,Guaranteed,PSM and eDRX,12/09/2024
 Croatia,HRV,21910,A1,NB-IoT,B20,plan01s,Guaranteed,PSM* and eDRX | SMS,08/20/2024
+Croatia,HRV,21910,A1,NB-IoT,B20,planNT1,Validated,PSM* and eDRX | SMS,01/23/2024
 Croatia,HRV,21910,A1,NB-IoT,B20,planX3,Validated,PSM* and eDRX | SMS,02/20/2025
+Croatia,HRV,21901,HT,NB-IoT,B8 | B20,planNT1,Validated,PSM*,07/01/2025
 Croatia,HRV,21901,HT,NB-IoT,B8 | B20,planX3,Validated,PSM*,12/09/2024
 Cyprus,CYP,28001,Cytamobile,NB-IoT,,plan01s,Observed,,06/06/2024
 Denmark,DNK,23801,TDC,NB-IoT,B20,plan01s,Guaranteed,PSM* and eDRX,07/02/2025
 Denmark,DNK,23802,Telenor,NB-IoT,B20,plan01s,Guaranteed,PSM,12/09/2024
+Denmark,DNK,23802,Telenor,NB-IoT,B20,planNT1,Guaranteed,PSM,10/02/2024
 Estonia,EST,24802,Elisa,NB-IoT,B20,planP1,Validated,PSM* and eDRX | SMS (MT),06/04/2024
 Estonia,EST,24802,Elisa,NB-IoT,B20,planX3,Validated,PSM* | SMS,09/30/2024
-Estonia,EST,24802,Elisa,NB-IoT,B20,plan01s,Validated,PSM* | SMS,07/02/2025
+Estonia,EST,24802,Elisa,NB-IoT,B20,plan01s,Guaranteed,PSM* | SMS,07/02/2025
+Faroe Islands,FRO,28801,Faroese Telecom,NB-IoT,B20,planNT1,Validated,,07/02/2025
 Faroe Islands,FRO,28801,Faroese Telecom,NB-IoT,B20,plan01s,Validated,,07/02/2025
 Faroe Islands,FRO,28801,Faroese Telecom,NB-IoT,B20,planX3,Validated,,07/02/2025
 Finland,FIN,24412,DNA,NB-IoT,B8 | B20,plan01s,Guaranteed,PSM* and eDRX | SMS,09/13/2024
+Finland,FIN,24412,DNA,NB-IoT,B8 | B20,planNT1,Guaranteed,PSM and eDRX,01/23/2024
 Finland,FIN,24412,DNA,NB-IoT,B8 | B20,planX3,Validated,PSM and eDRX,06/04/2024
 Germany,DEU,26203,O2,NB-IoT,B20,planX3,Validated,PSM*>=180min | SMS,09/26/2024
 Germany,DEU,26203,O2,NB-IoT,B20,plan01s,Guaranteed,PSM*>=180min | SMS,02/14/2025
+Germany,DEU,26203,O2,NB-IoT,B20,planNT1,Guaranteed,PSM*>=180min | SMS,09/17/2025
 Germany,DEU,26202,Vodafone,NB-IoT,B20,plan01s,Guaranteed,PSM* and eDRX,08/20/2024
 Greece,GRC,20205,Vodafone,NB-IoT,B20,plan01s,Guaranteed,PSM*,02/14/2025
+Greece,GRC,20205,Vodafone,NB-IoT,B20,planNT1,Validated,PSM*,07/02/2025
 Greece,GRC,20205,Vodafone,NB-IoT,B20,planX3,Validated,PSM*,06/04/2024
 Greece,GRC,20210,Wind,NB-IoT,B20,plan01s,Validated,PSM*,09/17/2024
 Greece,GRC,20210,Wind,NB-IoT,B20,planP1,Validated,PSM* and eDRX,06/04/2024
@@ -47,50 +59,63 @@ Italy,ITA,22201,TIM,NB-IoT,B20,planX3,Guaranteed,PSM* and eDRX,06/04/2024
 Italy,ITA,22210,Vodafone,NB-IoT,B20,plan01s,Guaranteed,PSM,06/25/2025
 Israel,ISR,42501,Partner,NB-IoT,B28,plan01s,Guaranteed,eDRX* | SMS,04/15/2025
 Latvia,LVA,24701,LMT,NB-IoT,B20,plan01s,Guaranteed,SMS,05/30/2024
+Latvia,LVA,24701,LMT,NB-IoT,B20,planNT1,Guaranteed,PSM* and eDRX | SMS,06/11/2025
 Luxembourg,LUX,27001,Post,NB-IoT,B20,plan01s,Validated,PSM* and eDRX | SMS,07/01/2025
+Luxembourg,LUX,27001,Post,NB-IoT,B20,planNT1,Validated,PSM* and eDRX | SMS,09/09/2025
 Luxembourg,LUX,27001,Post,NB-IoT,B20,planX3,Validated,PSM* and eDRX | SMS,07/01/2025
 Luxembourg,LUX,27077,Tango,NB-IoT,B20,plan01s,Validated,,12/30/2024
 Malaysia,MYS,50216,Digi,NB-IoT,B8,plan01s,Validated,PSM and eDRX,05/09/2025
 Malaysia,MYS,50216,Digi,NB-IoT,B8,planX3,Validated,PSM and eDRX,05/09/2025
 Malta,MLT,27877,Melita,NB-IoT,B20,plan01s,Guaranteed,PSM and eDRX* | SMS,04/29/2025
+Malta,MLT,27877,Melita,NB-IoT,B20,planNT1,Guaranteed,PSM and eDRX* | SMS,06/26/2025
 Mexico,MEX,334020,Telcel,NB-IoT,B5,plan01s,Validated,PSM* and eDRX | SMS,09/30/2024
 Netherlands,NLD,20404,Vodafone,NB-IoT,B20,plan01s,Guaranteed,PSM and eDRX,06/04/2024
 Norway,NOR,24201,Telenor,NB-IoT,B20,plan01s,Guaranteed,PSM and eDRX | SMS,09/13/2024
+Norway,NOR,24201,Telenor,NB-IoT,B20,planNT1,Guaranteed,PSM and eDRX | SMS,12/18/2024
 Puerto Rico,PRI,310260,T-Mobile,NB-IoT,B4,plan01s,Validated,PSM and eDRX,04/04/2024
+Puerto Rico,PRI,310260,T-Mobile,NB-IoT,B4,planNT1,Validated,PSM and eDRX,07/04/2025
 Russia,RUS,25001,MTS,NB-IoT,B3,plan01s,Guaranteed,PSM and eDRX,05/07/2025
 Singapore,SGP,52501,Singtel,NB-IoT,B3 | B8,plan01s,Validated,PSM* and eDRX,06/04/2024
-Singapore,SGP,52501,Singtel,NB-IoT,B3 | B8,planP1,Validated,PSM* and eDRX,06/04/2024
 Slovak Republic,SVK,23101,Orange,NB-IoT,B20,planX3,Guaranteed,PSM and eDRX,06/04/2024
 Slovenia,SVN,29340,A1,NB-IoT,B20,plan01s,Guaranteed,PSM and eDRX | SMS,07/04/2025
 Slovenia,SVN,29340,A1,NB-IoT,B20,planP1,Validated,PSM and eDRX,02/20/2025
+Slovenia,SVN,29340,A1,NB-IoT,B20,planNT1,Validated,PSM and eDRX | SMS,07/04/2025
 Slovenia,SVN,29340,A1,NB-IoT,B20,planX3,Validated,PSM and eDRX,02/20/2025
+South Africa,ZAF,65510,MTN,NB-IoT,B8,planNT1,Validated,PSM and eDRX,07/04/2025
 South Africa,ZAF,65501,Vodacom,NB-IoT,B8,plan01s,Validated,PSM and eDRX,11/28/2024
+South Africa,ZAF,65501,Vodacom,NB-IoT,B8,planNT1,Validated,PSM and eDRX,07/04/2025
 Spain,ESP,21403,Orange,NB-IoT,B8 | B20,plan01s,Validated,PSM* and eDRX,08/20/2024
+Spain,ESP,21403,Orange,NB-IoT,B8 | B20,planNT1,Validated,PSM* and eDRX,07/04/2025
 Spain,ESP,21403,Orange,NB-IoT,B8 | B20,planX3,Validated,SMS,06/04/2024
 Spain,ESP,21407,Movistar,NB-IoT,B20,plan01s,Guaranteed,PSM and eDRX | SMS,07/04/2025
 Spain,ESP,21401,Vodafone,NB-IoT,B20,plan01s,Guaranteed,PSM and eDRX | SMS,08/20/2024
 Switzerland,CHE,22801,Swisscom,NB-IoT,B20,plan01s,Guaranteed,PSM* and eDRX | SMS,06/04/2024
 Switzerland,CHE,22802,Sunrise,NB-IoT,B20,plan01s,Guaranteed,PSM* and eDRX | SMS,06/04/2024
+Switzerland,CHE,22802,Sunrise,NB-IoT,B20,planNT1,Guaranteed,PSM and eDRX | SMS,06/11/2025
 Taiwan,TWN,46692,Chunghwa Telecom,NB-IoT,B8 | (B28),plan01s,Guaranteed,PSM* and eDRX,08/20/2024
+Taiwan,TWN,46692,Chunghwa Telecom,NB-IoT,B8 | (B28),planNT1,Guaranteed,PSM* and eDRX,06/26/2025
 Turkey,TUR,28601,Turkcell,NB-IoT,B20,plan01s,Guaranteed,PSM* and eDRX,02/14/2025
 Ukraine,UKR,25506,Lifecell,NB-IoT,B3,plan01s,Validated,PSM and eDRX,02/14/2025
 United Kingdom,GBR,23430,EE,NB-IoT,B3,plan01s,Guaranteed,PSM* and eDRX | SMS,06/16/2025
+United Kingdom,GBR,23430,EE,NB-IoT,B3,planNT1,Validated,PSM* and eDRX | SMS,04/11/2025
 United Kingdom,GBR,23415,Vodafone,NB-IoT,B20,planX3,Guaranteed,PSM*,04/04/2025
 United States,USA,310410,AT&T,NB-IoT,B2 | B4 | B12 | B17 | B85,plan-US,Validated,PSM and eDRX,06/04/2024
 United States,USA,311588,US Cellular,NB-IoT,B12,planUS,Guaranteed,PSM* and eDRX | SMS,07/04/2024
 United States,USA,310260,T-Mobile,NB-IoT,B4 | B2 | B12,plan01s,Guaranteed,PSM and eDRX,08/20/2024
-United States,USA,310260,T-Mobile,NB-IoT,B4 | B2 | B12,plan-NA1,Guaranteed,PSM and eDRX,05/23/2024
-Uruguay,URY,74801,Antel,NB-IoT,B3 | B28,plan01s,Validated,PSM and eDRX | SMS,06/04/2024
+United States,USA,310260,T-Mobile,NB-IoT,B4 | B2 | B12,planNT1,Guaranteed,PSM and eDRX,06/13/2025
 Argentina,ARG,722310,Claro,LTE-M,B28,plan01s,Validated,SMS,10/29/2024
 Argentina,ARG,72207,Movistar,LTE-M,B4,plan01s,Validated,SMS,01/30/2024
+Argentina,ARG,72207,Movistar,LTE-M,B4,planNT1,Validated,SMS,06/05/2025
 Australia,AUS,50501,Telstra,LTE-M,(B3) | B28,plan01s,Guaranteed,PSM* and eDRX | SMS,05/28/2024
 Australia,AUS,50501,Telstra,LTE-M,(B3) | B28,planP1,Validated,PSM* and eDRX | SMS,08/01/2024
 Austria,AUT,23201,A1,LTE-M,B20,plan01s,Guaranteed,PSM and eDRX | SMS,09/30/2024
 Austria,AUT,23201,A1,LTE-M,B20,planX3,Guaranteed,PSM and eDRX | SMS,11/05/2024
 Austria,AUT,23203,Magenta,LTE-M,(B3) | B8 | B20,plan01s,Guaranteed,PSM and eDRX | SMS,08/04/2025
+Austria,AUT,23203,Magenta,LTE-M,(B3) | B8 | B20,planNT1,Guaranteed,PSM and eDRX | SMS,08/04/2025
 Belgium,BEL,20620,Base,LTE-M,B20,plan01s,Guaranteed,,05/01/2025
 Belgium,BEL,20610,Orange,LTE-M,B20,plan01s,Guaranteed,PSM* and eDRX | SMS,01/30/2024
 Belgium,BEL,20610,Orange,LTE-M,B20,planX3,Guaranteed,PSM* and eDRX | SMS,05/30/2024
+Belgium,BEL,20610,Orange,LTE-M,B20,planNT1,Guaranteed,SMS,06/05/2025
 Belgium,BEL,20610,Orange,LTE-M,B20,planP1,Validated,SMS,06/03/2024
 Belgium,BEL,20601,Proximus,LTE-M,B20,plan01s,Guaranteed,PSM and eDRX | SMS,05/01/2025
 Belgium,BEL,20601,Proximus,LTE-M,B20,planX3,Validated,SMS,05/30/2024
@@ -107,15 +132,18 @@ Canada,CAN,302720,Rogers,LTE-M,B4 | B5 | B12 | B85,planP1,Validated,SMS,06/03/20
 Canada,CAN,302720,Rogers,LTE-M,B4 | B5 | B12 | B85,plan-US-NA,Validated,SMS,06/03/2024
 Canada,CAN,302220,Telus,LTE-M,B12 | B17,plan01s,Guaranteed,PSM and eDRX | SMS,05/06/2025
 Canada,CAN,302220,Telus,LTE-M,B12 | B17,plan-NA1,Guaranteed,PSM and eDRX | SMS,05/06/2025
+Canada,CAN,302220,Telus,LTE-M,B12 | B17,planNT1,Guaranteed,PSM and eDRX | SMS,12/19/2024
 Canada,CAN,302500,Videotron,LTE-M,B12 | B85,plan01s,Validated,SMS,06/05/2024
 Canada,CAN,302500,Videotron,LTE-M,B12 | B85,plan-NA1,Validated,SMS,06/05/2024
 Colombia,COL,732123,Movistar,LTE-M,B5,plan01s,Validated,SMS,07/24/2024
 Costa Rica,CRI,71203,Claro,LTE-M,B3,plan01s,Guaranteed,SMS,01/30/2024
+Costa Rica,CRI,71203,Claro,LTE-M,B3,planNT1,Validated,SMS,07/28/2025
 Costa Rica,CRI,71204,Movistar,LTE-M,B3,plan01s,Validated,SMS,01/03/2024
 Croatia,HRV,21910,A1,LTE-M,B20,plan01s,Validated,PSM* and eDRX | SMS,01/14/2025
 Croatia,HRV,21910,A1,LTE-M,B20,planX3,Validated,PSM* and eDRX | SMS,01/14/2025
 Croatia,HRV,21901,HT,LTE-M,B20,plan01s,Validated,PSM* | SMS,07/17/2025
 Croatia,HRV,21901,HT,LTE-M,B20,planX3,Validated,PSM* | SMS,07/17/2025
+Croatia,HRV,21901,HT,LTE-M,B20,planNT1,Validated,PSM* | SMS,07/17/2025
 Czech Republic,CZE,23002,O2,LTE-M,B20,plan01s,Guaranteed,SMS,04/01/2025
 Czech Republic,CZE,23002,O2,LTE-M,B20,planX3,,,07/17/2025
 Czech Republic,CZE,23001,T-Mobile,LTE-M,B20,plan01s,Validated,SMS,07/17/2025
@@ -123,24 +151,32 @@ Czech Republic,CZE,23001,T-Mobile,LTE-M,B20,planP1,Validated,SMS,01/02/2024
 Czech Republic,CZE,23003,Vodafone,LTE-M,B3 | B20,plan01s,Guaranteed,PSM* and eDRX | SMS,11/19/2024
 Czech Republic,CZE,23003,Vodafone,LTE-M,B3 | B20,planX3,Guaranteed,PSM* and eDRX | SMS,02/02/2024
 Denmark,DNK,23806,3,LTE-M,B8 | B20,plan01s,Guaranteed,PSM and eDRX | SMS,10/29/2024
+Denmark,DNK,23806,3,LTE-M,B8 | B20,planNT1,Guaranteed,PSM and eDRX | SMS,09/10/2025
 Denmark,DNK,23806,3,LTE-M,B8 | B20,planP1,Validated,SMS,01/02/2024
 Denmark,DNK,23801,TDC,LTE-M,B20,plan01s,Guaranteed,PSM* or eDRX | SMS,10/29/2024
 Denmark,DNK,23802,Telenor,LTE-M,B20,plan01s,Guaranteed,PSM | SMS,09/13/2024
+Denmark,DNK,23802,Telenor,LTE-M,B20,planNT1,Guaranteed,PSM and eDRX <=40s | SMS,09/10/2025
 Denmark,DNK,23802,Telenor,LTE-M,B20,planX3,Guaranteed,PSM | SMS,04/23/2024
 Denmark,DNK,23820,Telia,LTE-M,B20,plan01s,Guaranteed,PSM and eDRX | SMS,09/13/2024
+Denmark,DNK,23820,Telia,LTE-M,B20,planNT1,Guaranteed,PSM and eDRX | SMS,09/10/2025
 Denmark,DNK,23820,Telia,LTE-M,B20,planX3,Guaranteed,PSM | SMS,06/10/2024
 Denmark,DNK,23820,Telia,LTE-M,B20,planP1,Validated,SMS,11/19/2024
 Ecuador,ECU,74000,Movistar,LTE-M,B2,plan01s,Validated,SMS,11/04/2024
+Ecuador,ECU,74000,Movistar,LTE-M,B2,planNT1,Validated,SMS,08/05/2025
 El Salvador,SLV,70601,Claro,LTE-M,B2,plan01s,Guaranteed,PSM* | SMS,04/04/2025
 Estonia,EST,24802,Elisa,LTE-M,B3,plan01s,Guaranteed,PSM* | SMS,06/10/2024
 Estonia,EST,24802,Elisa,LTE-M,B3,planX3,Validated,PSM* | SMS,06/05/2024
 Estonia,EST,24802,Elisa,LTE-M,B3,planP1,Validated,PSM* | SMS,06/05/2024
 Estonia,EST,24801,Telia,LTE-M,B3 | B20,plan01s,Validated,SMS,04/26/2024
+Estonia,EST,24801,Telia,LTE-M,B3 | B20,planNT1,Validated,SMS,01/17/2024
 Estonia,EST,24801,Telia,LTE-M,B3 | B20,planX3,Validated,SMS,06/05/2024
 Estonia,EST,24801,Telia,LTE-M,B3 | B20,planP1,Validated,SMS,06/05/2024
+Estonia,EST,24803,Tele2,LTE-M,B20,plan01s,Validated,SMS,09/09/2025
+Estonia,EST,24803,Tele2,LTE-M,B20,planNT1,Validated,SMS,09/15/2025
 Faroe Islands,FRO,28801,Faroese Telecom,LTE-M,B20,plan01s,Validated,SMS,01/13/2025
 Faroe Islands,FRO,28802,Hey,LTE-M,B20,plan01s,Validated,SMS,01/13/2025
 Finland,FIN,24412,DNA,LTE-M,B20,plan01s,Guaranteed,PSM* and eDRX | SMS,09/13/2024
+Finland,FIN,24412,DNA,LTE-M,B20,planNT1,Guaranteed,PSM* and eDRX | SMS,10/02/2024
 Finland,FIN,24412,DNA,LTE-M,B20,planX3,Guaranteed,PSM* and eDRX | SMS,04/23/2024
 Finland,FIN,24405,Elisa,LTE-M,B20,plan01s,Guaranteed,PSM* and eDRX | SMS,05/13/2024
 Finland,FIN,24491,Telia,LTE-M,B1 | B3 | B7 | B20 | B28,plan01s,Validated,SMS,04/26/2024
@@ -148,9 +184,11 @@ Finland,FIN,24491,Telia,LTE-M,B1 | B3 | B7 | B20 | B28,planX3,Validated,SMS,01/1
 Finland,FIN,24491,Telia,LTE-M,B1 | B3 | B7 | B20 | B28,planP1,Validated,SMS,06/10/2024
 France,FRA,20820,Bouygues,LTE-M,B20,plan01s,Guaranteed,PSM* and eDRX | SMS,05/07/2025
 France,FRA,20801,Orange,LTE-M,B20,plan01s,Guaranteed,PSM* and eDRX | SMS,10/29/2024
+France,FRA,20801,Orange,LTE-M,B20,planNT1,Validated,SMS,01/18/2024
 France,FRA,20801,Orange,LTE-M,B20,planX3,Guaranteed,PSM* and eDRX | SMS,06/23/2025
 France,FRA,20810,SFR,LTE-M,B20,plan01s,Validated,SMS,04/26/2024
 Germany,DEU,26203,O2,LTE-M,B20,plan01s,Guaranteed,PSM*>=180min | SMS,04/01/2025
+Germany,DEU,26203,O2,LTE-M,B20,planNT1,Guaranteed,PSM*>=180min | SMS,09/10/2025
 Germany,DEU,26203,O2,LTE-M,B20,planX3,Guaranteed,PSM*>=180min | SMS,09/26/2024
 Germany,DEU,26201,Telekom.de,LTE-M,B3 | B20,planP1,Validated,SMS,07/17/2025
 Germany,DEU,26202,Vodafone,LTE-M,B20,plan01s,Guaranteed,PSM* and eDRX | SMS,04/01/2025
@@ -159,28 +197,37 @@ Greece,GRC,20205,Vodafone,LTE-M,B20,plan01s,Validated,PSM* | SMS,01/12/2024
 Greece,GRC,20205,Vodafone,LTE-M,B20,planX3,Validated,PSM* | SMS,01/12/2024
 Greece,GRC,20210,Wind,LTE-M,B20,plan01s,Validated,PSM* | SMS,07/01/2024
 Greece,GRC,20210,Wind,LTE-M,B20,planP1,Validated,PSM* | SMS,07/01/2024
+Guadeloupe,GLP,34001,Orange,LTE-M,B3,plan01s,Validated,SMS,09/09/2025
+Guadeloupe,GLP,34001,Orange,LTE-M,B3,planX3,Validated,SMS,09/09/2025
 Honduras,HND,708001,Claro,LTE-M,B2,plan01s,Validated,PSM | SMS,07/04/2025
 Hungary,HUN,21630,Telekom.hu,LTE-M,B3 | B20,plan01s,Guaranteed,PSM | SMS,06/16/2025
 Hungary,HUN,21630,Telekom.hu,LTE-M,B3 | B20,planP1,Validated,SMS,01/16/2024
 Hungary,HUN,21601,Yettel,LTE-M,B20,planX3,Validated,SMS,06/10/2024
 Hungary,HUN,21670,Vodafone,LTE-M,B20,plan01s,Validated,SMS,06/06/2024
+Hungary,HUN,21670,Vodafone,LTE-M,B20,planNT1,Validated,PSM* and eDRX | SMS,01/18/2024
 Iceland,ISL,27402,Vodafone,LTE-M,B20,plan01s,Validated,SMS,07/01/2024
 Iceland,ISL,27411,Nova,LTE-M,B20,plan01s,Validated,SMS,06/06/2024
 Ireland,IRL,27205,3,LTE-M,B20,plan01s,Guaranteed,PSM and eDRX | SMS,06/09/2025
+Ireland,IRL,27205,3,LTE-M,B20,planNT1,Validated,SMS,04/24/2025
 Ireland,IRL,27205,3,LTE-M,B20,planX3,Validated,SMS,04/24/2025
 Ireland,IRL,27205,3,LTE-M,B20,planP1,Validated,SMS,06/06/2024
 Israel,ISR,42503,Pelephone,LTE-M,B3 | B28,plan01s,Validated,PSM* and eDRX | SMS,09/23/2024
+Israel,ISR,42503,Pelephone,LTE-M,B3 | B28,planNT1,Validated,PSM* and eDRX | SMS,09/23/2024
 Israel,ISR,42502,Cellcom,LTE-M,B3,plan01s,Validated,PSM and eDRX | SMS,09/23/2024
 Israel,ISR,42501,Partner,LTE-M,B3,plan01s,Guaranteed,PSM and eDRX | SMS,04/01/2025
-Italy,ITA,22210,Vodafone,LTE-M,B3 | B20,plan01s,Validated,eDRX* (81.92) and PSM* | SMS,06/25/2025
+Italy,ITA,22210,Vodafone,LTE-M,B3 | B20,plan01s,Guaranteed,eDRX* (81.92) and PSM* | SMS,06/25/2025
 Italy,ITA,22210,Vodafone,LTE-M,B3 | B20,planX3,Validated,eDRX* (81.92) and PSM* | SMS,06/25/2025
 Japan,JPN,44010,NTT Docomo,LTE-M,B1 | B19,plan-D,Guaranteed,PSM and eDRX | SMS,01/12/2024
+Japan,JPN,44010,NTT Docomo,LTE-M,B1 | B19,planNT1,Guaranteed,PSM* and eDRX | SMS,10/02/2024
 Japan,JPN,44010,NTT Docomo,LTE-M,B1 | B19,plan01s,Guaranteed,PSM* and eDRX | SMS,07/24/2025
 Japan,JPN,44010,NTT Docomo,LTE-M,B1 | B19,planX3,Guaranteed,PSM* and eDRX | SMS,07/01/2024
 Japan,JPN,44020,SoftBank,LTE-M,B1 | B8,plan01s,Guaranteed,PSM and eDRX | SMS,06/06/2024
 Japan,JPN,44020,SoftBank,LTE-M,B1 | B8,planP1,Validated,PSM and eDRX | SMS,06/06/2024
+Japan,JPN,44020,SoftBank,LTE-M,B1 | B8,planNT1,Guaranteed,PSM and eDRX | SMS,11/22/2024
 Japan,JPN,44020,SoftBank,LTE-M,B1 | B8,planX3,Guaranteed,PSM and eDRX | SMS,02/01/2024
+Jersey,GBR,23450,Jersey Telecom,LTE-M,B20,plan01s,Guaranteed,,09/15/2025
 Latvia,LVA,24701,LMT,LTE-M,B20,plan01s,Guaranteed,PSM and eDRX | SMS,11/11/2024
+Latvia,LVA,24701,LMT,LTE-M,B20,planNT1,Guaranteed,PSM* and eDRX | SMS,06/12/2025
 Latvia,LVA,24701,LMT,LTE-M,B20,planP1,Validated,SMS,01/23/2024
 Latvia,LVA,24701,LMT,LTE-M,B20,planX3,Guaranteed,PSM* | SMS,06/06/2024
 La Reunion,REU,64700,Orange,LTE-M,B20,planX3,Guaranteed,PSM* and eDRX | SMS,10/22/2024
@@ -190,44 +237,54 @@ Liechtenstein,LIE,29505,FL1,LTE-M,B20,plan01s,Guaranteed,PSM and eDRX | SMS,09/0
 Liechtenstein,LIE,29505,FL1,LTE-M,B20,planP1,Validated,SMS,11/21/2024
 Liechtenstein,LIE,29505,FL1,LTE-M,B20,planX3,Guaranteed,PSM and eDRX | SMS,07/24/2025
 Lithuania,LTU,24601,Telia,LTE-M,B8,plan01s,Validated,SMS,01/26/2024
+Lithuania,LTU,24601,Telia,LTE-M,B8,planNT1,Validated,SMS,01/18/2024
 Lithuania,LTU,24601,Telia,LTE-M,B8,planP1,Validated,SMS,01/16/2024
 Lithuania,LTU,24601,Telia,LTE-M,B8,planX3,Validated,SMS,01/26/2024
 Luxembourg,LUX,27001,Post,LTE-M,B20,plan01s,Guaranteed,PSM* and eDRX | SMS,06/06/2024
+Luxembourg,LUX,27001,Post,LTE-M,B20,planNT1,Validated,eDRX | SMS,01/18/2024
 Luxembourg,LUX,27001,Post,LTE-M,B20,planX3,Guaranteed,PSM* and eDRX | SMS,07/24/2024
 Mayotte,MYT,64700,Orange,LTE-M,B20,planX3,Guaranteed,PSM* or eDRX | SMS,10/29/2024
 Mayotte,MYT,64710,SFR,LTE-M,B20,plan01s,Validated,SMS,10/29/2024
 Mexico,MEX,334020,Telcel,LTE-M,B4,plan01s,Validated,PSM* and eDRX | SMS,01/30/2024
 Mexico,MEX,334020,Telcel,LTE-M,B4,planX3,Validated,PSM* and eDRX | SMS,06/10/2024
 Mexico,MEX,33403,Movistar,LTE-M,B4,plan01s,Guaranteed,PSM and eDRX | SMS,01/20/2025
+Mexico,MEX,334030,Movistar,LTE-M,B4,planNT1,Validated,eDRX | SMS,01/18/2024
 Mexico,MEX,334090,AT&T,LTE-M,B4,planP1,Validated,SMS,07/04/2025
 Mexico,MEX,334090,AT&T,LTE-M,B4,plan-US-NA,Validated,SMS,07/04/2025
 Mexico,MEX,334090,AT&T,LTE-M,B4,plan01s,Validated,SMS,01/20/2025
 Mexico,MEX,334050,AT&T,LTE-M,B4,plan01s,Guaranteed,SMS,01/20/2025
 Netherlands,NLD,20408,KPN,LTE-M,B20,plan01s,Guaranteed,PSM and eDRX | SMS,06/06/2024
+Netherlands,NLD,20408,KPN,LTE-M,B20,planNT1,Validated,eDRX | SMS,01/18/2024
 Netherlands,NLD,20408,KPN,LTE-M,B20,planP1,Validated,SMS,06/06/2024
 Netherlands,NLD,20408,KPN,LTE-M,B20,planX3,Guaranteed,PSM and eDRX | SMS,04/18/2024
 Netherlands,NLD,20416,T-Mobile,LTE-M,B20,planP1,Validated,PSM and eDRX | SMS,06/06/2024
 Netherlands,NLD,20404,Vodafone,LTE-M,B8 | B20,plan01s,Guaranteed,PSM* and eDRX | SMS,06/06/2024
+Netherlands,NLD,20404,Vodafone,LTE-M,B8 | B20,planNT1,Validated,PSM* and eDRX | SMS,01/18/2024
 Netherlands,NLD,20404,Vodafone,LTE-M,B8 | B20,planX3,Guaranteed,PSM* and eDRX | SMS,04/18/2024
 New Zealand,NZL,53005,Spark,LTE-M,B28,plan01s,Guaranteed,SMS,08/04/2025
+New Zealand,NZL,53005,Spark,LTE-M,B28,planNT1,Validated,SMS,01/18/2024
 New Zealand,NZL,53005,Spark,LTE-M,B28,planP1,Validated,SMS,07/28/2025
 New Zealand,NZL,53001,Vodafone,LTE-M,B3 | B28,plan01s,Validated,SMS,04/26/2024
 New Zealand,NZL,53001,Vodafone,LTE-M,B3 | B28,planX3,Validated,SMS,02/20/2025
 Nicaragua,NIC,71021,Enitel,LTE-M,B2,plan01s,Guaranteed,PSM* | SMS,05/06/2025
 Norway,NOR,24201,Telenor,LTE-M,B20,plan01s,Guaranteed,PSM and eDRX | SMS,09/13/2024
+Norway,NOR,24201,Telenor,LTE-M,B20,planNT1,Guaranteed,PSM and eDRX | SMS,10/02/2024
 Norway,NOR,24201,Telenor,LTE-M,B20,planX3,Guaranteed,PSM | SMS,07/24/2024
 Norway,NOR,24202,Telia,LTE-M,B20,plan01s,Guaranteed,PSM and eDRX | SMS,09/13/2024
+Norway,NOR,24202,Telia,LTE-M,B20,planNT1,Guaranteed,PSM and eDRX | SMS,10/02/2024
 Norway,NOR,24202,Telia,LTE-M,B20,planX3,Validated,SMS,02/20/2025
 Norway,NOR,24202,Telia,LTE-M,B20,planP1,Validated,SMS,06/10/2024
 Poland,POL,26003,Orange,LTE-M,B20,plan01s,Guaranteed,PSM and eDRX | SMS,02/04/2025
 Poland,POL,26003,Orange,LTE-M,B20,planX3,Guaranteed,PSM | SMS,06/10/2024
 Poland,POL,26003,Orange,LTE-M,B20,planP1,Validated,SMS,06/10/2024
 Portugal,PRT,26806,MEO,LTE-M,B20,plan01s,Validated,SMS,04/26/2024
+Portugal,PRT,26806,MEO,LTE-M,B20,planNT1,Validated,SMS,01/18/2024
 Portugal,PRT,26801,Vodafone,LTE-M,B20,plan01s,Guaranteed,PSM* | SMS,02/04/2025
 Portugal,PRT,26801,Vodafone,LTE-M,B20,planX3,Guaranteed,PSM* | SMS,06/10/2024
 Portugal,PRT,26803,NOS,LTE-M,B20,planX3,Validated,SMS,06/10/2024
 Puerto Rico,PRI,330110,Claro,LTE-M,B4,plan01s,Validated,PSM* and eDRX | SMS,01/12/2024
 Puerto Rico,PRI,310260,T-Mobile,LTE-M,B2,plan01s,Guaranteed,PSM and eDRX | SMS,04/10/2025
+Puerto Rico,PRI,310260,T-Mobile,LTE-M,B2,planNT1,Guaranteed,SMS,10/02/2024
 Qatar,QAT,42701,Ooredoo,LTE-M,B20,plan01s,Validated,SMS,06/06/2024
 Romania,ROU,22601,Vodafone,LTE-M,B20,plan01s,Validated,SMS,01/30/2024
 Romania,ROU,22601,Vodafone,LTE-M,B20,planX3,Validated,SMS,06/10/2024
@@ -235,27 +292,34 @@ Romania,ROU,22610,Orange,LTE-M,B3,planX3,Guaranteed,PSM* and eDRX | SMS,01/12/20
 Romania,ROU,22610,Orange,LTE-M,B3,planP1,Validated,SMS,01/12/2024
 Senegal,SEN,60801,Orange,LTE-M,B20,planX3,Validated,SMS,01/13/2025
 Serbia,RS,22005,A1,LTE-M,B20,plan01s,Validated,PSM and eDRX | SMS,04/29/2024
+Serbia,RS,22005,A1,LTE-M,B20,planNT1,Validated,PSM and eDRX | SMS,04/29/2024
 Singapore,SGP,52501,Singtel,LTE-M,B3,plan01s,Validated,PSM* and eDRX | SMS,01/30/2024
-Singapore,SGP,52501,Singtel,LTE-M,B3,planP1,Validated,PSM and eDRX | SMS,06/10/2024
 Slovenia,SVN,29340,A1,LTE-M,B20,plan01s,Guaranteed,PSM and eDRX | SMS,06/05/2024
+Slovenia,SVN,29340,A1,LTE-M,B20,planNT1,Validated,eDRX | SMS,01/18/2024
 Slovenia,SVN,29340,A1,LTE-M,B20,planP1,Validated,SMS,02/20/2025
 Slovenia,SVN,29340,A1,LTE-M,B20,planX3,Validated,PSM and eDRX | SMS,06/06/2024
 Slovakia,SVK,23101,Orange,LTE-M,B20,plan01s,Validated,SMS,01/30/2024
 Slovakia,SVK,23101,Orange,LTE-M,B20,planX3,Guaranteed,PSM and eDRX | SMS,04/23/2024
 South Korea,KOR,45008,KT,LTE-M,B3,plan01s,Validated,PSM | SMS,07/24/2024
 South Korea,KOR,45005,SKTelecom,LTE-M,B5,plan01s,Validated,SMS,06/10/2024
+South Korea,KOR,45005,SKTelecom,LTE-M,B5,planNT1,Validated,SMS,01/18/2024
 South Korea,KOR,45005,SKTelecom,LTE-M,B5,planP1,Validated,SMS,06/10/2024
 South Korea,KOR,45005,SKTelecom,LTE-M,B5,planX3,Validated,SMS,11/27/2024
 Spain,ESP,21403,Orange,LTE-M,B20,plan01s,Validated,PSM* and eDRX | SMS,04/26/2024
+Spain,ESP,21403,Orange,LTE-M,B20,planNT1,Validated,eDRX | SMS,01/18/2024
 Spain,ESP,21403,Orange,LTE-M,B20,planX3,Guaranteed,PSM* and eDRX | SMS,06/10/2024
 Spain,ESP,21407,Movistar,LTE-M,B3,planX3,Guaranteed,PSM and eDRX | SMS,06/10/2024
 Spain,ESP,21407,Movistar,LTE-M,B3,plan01s,Guaranteed,PSM* and eDRX | SMS,10/07/2024
+Spain,ESP,21407,Movistar,LTE-M,B3,planNT1,Guaranteed,PSM and eDRX | SMS,08/13/2025
 Spain,ESP,21401,Vodafone,LTE-M,B20,plan01s,Guaranteed,PSM | SMS,06/26/2025
 Spain,ESP,21401,Vodafone,LTE-M,B20,planX3,Validated,SMS,06/05/2024
 Sweden,SWE,24007,Tele2,LTE-M,B20,plan01s,Validated,SMS,04/26/2024
+Sweden,SWE,24007,Tele2,LTE-M,B20,planNT1,Validated,SMS,01/18/2024
 Sweden,SWE,24008,Telenor,LTE-M,B20,plan01s,Guaranteed,SMS,10/31/2024
+Sweden,SWE,24008,Telenor,LTE-M,B20,planNT1,Guaranteed,SMS,10/02/2024
 Sweden,SWE,24008,Telenor,LTE-M,B20,planX3,Guaranteed,PSM and eDRX | SMS,04/23/2024
 Sweden,SWE,24001,Telia,LTE-M,B3 | B20,plan01s,Guaranteed,SMS,09/13/2024
+Sweden,SWE,24001,Telia,LTE-M,B3 | B20,planNT1,Guaranteed,PSM and eDRX | SMS,10/02/2024
 Sweden,SWE,24001,Telia,LTE-M,B3 | B20,planX3,Guaranteed,PSM and eDRX | SMS,06/10/2024
 Sweden,SWE,24001,Telia,LTE-M,B3 | B20,planP1,Validated,SMS,06/10/2024
 Sweden,SWE,24002,3,LTE-M,B20,plan01s,Guaranteed,PSM and eDRX | SMS,05/09/2025
@@ -263,32 +327,37 @@ Sweden,SWE,24002,3,LTE-M,B20,planP1,Validated,PSM and eDRX | SMS,10/31/2024
 Switzerland,CHE,22801,Swisscom,LTE-M,B20,plan01s,Guaranteed,PSM* and eDRX | SMS,06/10/2024
 Switzerland,CHE,22802,Sunrise,LTE-M,B20,plan01s,Guaranteed,PSM and eDRX | SMS,10/07/2024
 Switzerland,CHE,22802,Sunrise,LTE-M,B20,planP1,Validated,SMS,07/04/2025
+Switzerland,CHE,22802,Sunrise,LTE-M,B20,planNT1,Guaranteed,PSM and eDRX | SMS,06/11/2025
 Switzerland,CHE,22802,Sunrise,LTE-M,B20,planX3,Validated,SMS,01/05/2024
 Taiwan,TWN,46692,Chunghwa Telecom,LTE-M,B3,plan01s,Guaranteed,PSM* and eDRX | SMS,06/10/2024
+Taiwan,TWN,46692,Chunghwa Telecom,LTE-M,B3,planNT1,Guaranteed,PSM* and eDRX | SMS,11/18/2024
 Taiwan,TWN,46692,Chunghwa Telecom,LTE-M,B3,planX3,Guaranteed,PSM* and eDRX | SMS,06/10/2024
 Taiwan,TWN,46601,FarEasTone,LTE-M,B28,planP1,Validated,PSM* and eDRX | SMS,02/13/2025
 Turkey,TUR,28601,Turkcell,LTE-M,B20,plan01s,Guaranteed,SMS,11/08/2024
+Turkey,TUR,28601,Turkcell,LTE-M,B20,planNT1,Validated,SMS,07/24/2024
 Turkey,TUR,28602,Vodafone,LTE-M,B20,plan01s,Validated,SMS,11/28/2024
 United Arab Emirates,ARE,42402,Etisalat,LTE-M,B20,plan01s,Validated,SMS,06/27/2025
 United Kingdom,GBR,23410,O2,LTE-M,B20,plan01s,Guaranteed,PSM* and eDRX | SMS,06/24/2024
+United Kingdom,GBR,23410,O2,LTE-M,B20,planNT1,Validated,SMS,06/24/2024
 United Kingdom,GBR,23430,EE,LTE-M,B3,plan01s,Guaranteed,PSM* and eDRX | SMS,04/09/2025
+United Kingdom,GBR,23430,EE,LTE-M,B3,planNT1,Validated,PSM* and eDRX | SMS,04/09/2025
 United Kingdom,GBR,23415,Vodafone,LTE-M,B20,planX3,Validated,SMS,06/06/2024
 United Kingdom,GBR,23415,Vodafone,LTE-M,B20,plan01s,Guaranteed,SMS,01/20/2025
+United Kingdom,GBR,23415,Vodafone,LTE-M,B20,planNT1,Validated,SMS,01/18/2024
+United Kingdom,GBR,23420,3,LTE-M,B20,plan01s,Validated,SMS,09/09/2025
+United Kingdom,GBR,23420,3,LTE-M,B20,planNT1,Validated,SMS,09/09/2025
+United Kingdom,GBR,23420,3,LTE-M,B20,planP1,Validated,SMS,09/09/2025
+United Kingdom,GBR,23420,3,LTE-M,B20,planX3,Validated,SMS,09/09/2025
 Uruguay,URY,74801,Antel,LTE-M,B28,plan01s,Validated,PSM and eDRX | SMS,04/30/2024
 Uruguay,URY,74807,Movistar,LTE-M,B28,plan01s,Validated,PSM* | SMS,01/20/2025
 Uruguay,URY,74810,Claro,LTE-M,B28,plan01s,Validated,SMS,04/30/2024
 United States,USA,310410,AT&T,LTE-M,B2 | B4 | B12 (B17),plan01s,Guaranteed,PSM and eDRX | SMS,06/06/2024
 United States,USA,310410,AT&T,LTE-M,B2 | B4 | B12 (B17),plan-NA1,Guaranteed,PSM and eDRX | SMS,06/06/2024
+United States,USA,310410,AT&T,LTE-M,B2 | B4 | B12 (B17),planNT1,Guaranteed,PSM and eDRX | SMS,05/03/2024
 United States,USA,310410,AT&T,LTE-M,B2 | B4 | B12 (B17),planP1,Validated,PSM and eDRX | SMS,06/06/2024
 United States,USA,310410,AT&T,LTE-M,B2 | B4 | B12 (B17),planUS,Guaranteed,PSM and eDRX | SMS,05/19/2025
 United States,USA,310410,AT&T,LTE-M,B2 | B4 | B12 (B17),plan-US-max,Guaranteed,PSM and eDRX | SMS,01/12/2024
 United States,USA,310410,AT&T,LTE-M,B2 | B4 | B12 (B17),planX3,Guaranteed,PSM and eDRX | SMS,06/06/2024
 United States,USA,310260,T-Mobile,LTE-M,B2 | B4 | B12 (B17) | B66 | B71,plan01s,Guaranteed,PSM* and eDRX | SMS,06/06/2024
 United States,USA,310260,T-Mobile,LTE-M,B2 | B4 | B12 (B17) | B66 | B71,plan-NA1,Guaranteed,PSM* and eDRX | SMS,06/06/2024
-United States,USA,310260,T-Mobile,LTE-M,B2 | B4 | B12 (B17) | B66 | B71,planP1,Validated,SMS,01/16/2024
-United States,USA,310260,T-Mobile,LTE-M,B2 | B4 | B12 (B17) | B66 | B71,plan-US-NA,Validated,SMS,01/16/2024
-United States,USA,310260,T-Mobile,LTE-M,B2 | B4 | B12 (B17) | B66 | B71,plan-US-max,Validated,SMS,08/06/2024
-United States,USA,310260,T-Mobile,LTE-M,B2 | B4 | B12 (B17) | B66 | B71,planX3,Validated,SMS,04/15/2024
-United States,USA,311588,US Cellular,LTE-M,B2 | B5 | B12,planUS,Guaranteed,PSM* and eDRX | SMS,07/04/2024
-United States - Alaska,USA,311480,Verizon,LTE-M,B13,planUS,Guaranteed,PSM* and eDRX | SMS,05/19/2025
-United States,USA,311480,Verizon,LTE-M,B13,plan-US-max,Validated,SMS,09/19/2024
+United States,USA,310260,T-Mobile,LTE-M,B2 | B4 | B12 (B17) | B66 | B71,planNT1,Guaranteed,PSM and eDRX,05/30/2025


### PR DESCRIPTION
latest footprint as of 19/09/2025 - including planX1 named as planNT1